### PR TITLE
fix!: nest lists as deeply as their level says, ship ESM only

### DIFF
--- a/.changeset/eighty-ducks-shave.md
+++ b/.changeset/eighty-ducks-shave.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/vue': major
+---
+
+The package is now ESM only, and requires Node.js 22.12 or later
+
+#### When you will see a difference
+
+Only if you load this package with `require()`, or build on Node.js 20 or earlier. If you already `import` it, or use a bundler, nothing changes.
+
+#### What changes
+
+The package no longer ships a CommonJS build. `require("@portabletext/vue")` will fail, where before it resolved to `dist/vue-portable-text.cjs`. Use `import` instead, or a dynamic `await import()` from a CommonJS file.
+
+This brings the package in line with the rest of the Portable Text packages, which are already ESM only.
+
+Node.js 20 reached end of life in April 2026. The package previously declared no `engines` range at all, so nothing was enforced.

--- a/.changeset/plenty-jars-invent.md
+++ b/.changeset/plenty-jars-invent.md
@@ -1,0 +1,58 @@
+---
+'@portabletext/vue': major
+---
+
+Lists now nest as deeply as their `level` says they do
+
+#### When you will see a difference
+
+Only when your content has a list item that starts deeper than level 1, or that jumps more than one level at a time, such as going straight from level 1 to level 3. Lists that start at level 1 and change one level at a time render exactly as before.
+
+Portable Text stores list nesting as a flat `level` number on each block, and an editor lets an author produce both of those shapes. Previously the rendered nesting could be shallower than `level` said, and an item returning to a shallower level could start a new list instead of continuing the one it belonged to, which restarts the numbering of an `<ol>`.
+
+#### What changes
+
+Two list items, the first at level 3 and the second at level 1, used to render as two unrelated lists:
+
+```html
+<ul>
+  <li>Level 3</li>
+</ul>
+<ul>
+  <li>Level 1</li>
+</ul>
+```
+
+They now render as one list, three levels deep, with the second item as a sibling at the top:
+
+```html
+<ul>
+  <li>
+    <ul>
+      <li>
+        <ul>
+          <li>Level 3</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>Level 1</li>
+</ul>
+```
+
+The levels nobody authored have to be filled with something, and HTML can only put a list inside a list item, so they become empty list items. A browser draws a bullet or a number for each of them.
+
+#### What you may need to do
+
+Tests covering lists that start deep or skip levels will need updating.
+
+If the empty markers are visible somewhere you do not want them, the durable fix is the content itself, since a list skipping from level 1 to level 3 usually means an authoring mistake. To hide them in the meantime, target list items whose only child is a nested list:
+
+```css
+li:has(> ul:only-child),
+li:has(> ol:only-child) {
+  list-style: none;
+}
+```
+
+Note that in an `<ol>` this hides the number but the item still counts, so the numbering of the items after it is unchanged.

--- a/package.json
+++ b/package.json
@@ -15,21 +15,15 @@
   },
   "license": "MIT",
   "author": "Rupert Dunk <rupert@rupertdunk.com> (https://rupertdunk.com)",
+  "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/vue-portable-text.d.mts",
-        "default": "./dist/vue-portable-text.mjs"
-      },
-      "require": {
-        "types": "./dist/vue-portable-text.d.cts",
-        "default": "./dist/vue-portable-text.cjs"
-      }
+      "types": "./dist/vue-portable-text.d.ts",
+      "default": "./dist/vue-portable-text.mjs"
     },
     "./*": "./*"
   },
-  "main": "./dist/vue-portable-text.cjs",
-  "module": "./dist/vue-portable-text.mjs",
+  "main": "./dist/vue-portable-text.mjs",
   "types": "./dist/vue-portable-text.d.ts",
   "files": [
     "dist"
@@ -53,8 +47,8 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@portabletext/toolkit": "^2.0.18",
-    "@portabletext/types": "^2.0.14"
+    "@portabletext/toolkit": "^6.0.0",
+    "@portabletext/types": "^4.0.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
@@ -78,6 +72,9 @@
     "vue": "^3.3.4"
   },
   "packageManager": "pnpm@9.1.3",
+  "engines": {
+    "node": ">=22.12"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@portabletext/toolkit':
-        specifier: ^2.0.18
-        version: 2.0.18
+        specifier: ^6.0.0
+        version: 6.0.0
       '@portabletext/types':
-        specifier: ^2.0.14
-        version: 2.0.14
+        specifier: ^4.0.2
+        version: 4.0.2
       vue:
         specifier: ^3.3.4
         version: 3.4.21(typescript@5.4.5)
@@ -359,13 +359,13 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@portabletext/toolkit@2.0.18':
-    resolution: {integrity: sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+  '@portabletext/toolkit@6.0.0':
+    resolution: {integrity: sha512-+qSqe0KnefuZfNLUhzQRTpbSKxslZof+3pNwxg0DC8dfZ1yLKyyBUw6iR7EpDL+SJlrnpiBfEcfmEuFitK1NSQ==}
+    engines: {node: '>=22.12'}
 
-  '@portabletext/types@2.0.14':
-    resolution: {integrity: sha512-LnAanK3vkn30gMqtGv5QoR0QT3fioOgqh1SBIiquAbtBcoETxhdvCfEMnv5CAuFiZMFLyRIgfpjWyIIVA2yOjQ==}
-    engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
+  '@portabletext/types@4.0.2':
+    resolution: {integrity: sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -1969,11 +1969,11 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@portabletext/toolkit@2.0.18':
+  '@portabletext/toolkit@6.0.0':
     dependencies:
-      '@portabletext/types': 2.0.14
+      '@portabletext/types': 4.0.2
 
-  '@portabletext/types@2.0.14': {}
+  '@portabletext/types@4.0.2': {}
 
   '@rollup/pluginutils@5.1.0(rollup@4.14.0)':
     dependencies:

--- a/test/fixtures/016-deep-weird-lists.ts
+++ b/test/fixtures/016-deep-weird-lists.ts
@@ -346,8 +346,13 @@ export default {
     '</li>',
     '<li>',
     'All the way back',
+    // Level 1 -> 3 skips a level, so an empty list item holds the generated level 2 list
+    '<ul>',
+    '<li>',
     '<ul>',
     '<li>Skip a step</li>',
+    '</ul>',
+    '</li>',
     '</ul>',
     '</li>',
     '</ul>',

--- a/test/fixtures/063-skipped-list-levels.ts
+++ b/test/fixtures/063-skipped-list-levels.ts
@@ -1,0 +1,117 @@
+import type { PortableTextBlock } from '@portabletext/types';
+
+const input: PortableTextBlock[] = [
+  {
+    _type: 'block',
+    _key: 'level-3-item-1',
+    style: 'normal',
+    level: 3,
+    listItem: 'number',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        text: 'Level 3, item 1',
+        marks: [],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'level-1-item-2',
+    style: 'normal',
+    level: 1,
+    listItem: 'number',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        text: 'Level 1, item 2',
+        marks: [],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'level-1-bullet',
+    style: 'normal',
+    level: 1,
+    listItem: 'bullet',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        text: 'Level 1 bullet',
+        marks: [],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'level-4-bullet',
+    style: 'normal',
+    level: 4,
+    listItem: 'bullet',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        text: 'Level 4 bullet',
+        marks: [],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'level-1-bullet-again',
+    style: 'normal',
+    level: 1,
+    listItem: 'bullet',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        text: 'Level 1 bullet again',
+        marks: [],
+      },
+    ],
+  },
+];
+
+export default {
+  input,
+  output: [
+    // Starts at level 3: two generated ancestor lists, each in an empty list item
+    '<ol>',
+    '<li>',
+    '<ol>',
+    '<li>',
+    '<ol>',
+    '<li>Level 3, item 1</li>',
+    '</ol>',
+    '</li>',
+    '</ol>',
+    '</li>',
+    '<li>Level 1, item 2</li>',
+    '</ol>',
+
+    // Level 1 -> 4: levels 2 and 3 are generated as empty list items
+    '<ul>',
+    '<li>',
+    'Level 1 bullet',
+    '<ul>',
+    '<li>',
+    '<ul>',
+    '<li>',
+    '<ul>',
+    '<li>Level 4 bullet</li>',
+    '</ul>',
+    '</li>',
+    '</ul>',
+    '</li>',
+    '</ul>',
+    '</li>',
+    '<li>Level 1 bullet again</li>',
+    '</ul>',
+  ].join(''),
+};

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -27,6 +27,7 @@ import customBlockType from './050-custom-block-type';
 import customMarks from './052-custom-marks';
 import overrideDefaultMarks from './053-override-default-marks';
 import listIssue from './060-list-issue';
+import skippedListLevels from './063-skipped-list-levels';
 import missingMarkComponent from './061-missing-mark-component';
 import customBlockTypeWithChildren from './062-custom-block-type-with-children';
 
@@ -62,4 +63,5 @@ export {
   overrideDefaultMarks,
   listIssue,
   missingMarkComponent,
+  skippedListLevels,
 };

--- a/test/portable-text.test.ts
+++ b/test/portable-text.test.ts
@@ -90,6 +90,12 @@ test('builds weirdly complex lists without any issues', () => {
   expect(result).toBe(output);
 });
 
+test('builds lists that start deeper than level 1 and skip levels', () => {
+  const { input, output } = fixtures.skippedListLevels;
+  const result = render({ value: input });
+  expect(result).toBe(output);
+});
+
 test('renders all default block styles', () => {
   const { input, output } = fixtures.allDefaultBlockStyles;
   const result = render({ value: input });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,40 +1,16 @@
 import path from 'path';
-import fs from 'fs';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({
-  plugins: [
-    vue(),
-    dts({
-      rollupTypes: true,
-      async afterBuild() {
-        // This is to satisfy typechecker here
-        // https://arethetypeswrong.github.io/
-        // but seems ugly, types should be emitted per build?
-        const src = path.resolve(__dirname, 'dist/vue-portable-text.d.ts');
-        const mts = path.resolve(__dirname, 'dist/vue-portable-text.d.mts');
-        await fs.copyFile(src, mts, () => {});
-        const cts = path.resolve(__dirname, 'dist/vue-portable-text.d.cts');
-        await fs.copyFile(src, cts, () => {});
-      },
-    }),
-  ],
+  plugins: [vue(), dts({ rollupTypes: true })],
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'vue-portable-text',
-      formats: ['es', 'cjs'],
-      fileName: (format) => {
-        if (format === 'es') {
-          return `vue-portable-text.mjs`;
-        }
-        if (format === 'cjs') {
-          return `vue-portable-text.cjs`;
-        }
-        return `vue-portable-text.${format}.js`;
-      },
+      formats: ['es'],
+      fileName: () => `vue-portable-text.mjs`,
     },
     rollupOptions: {
       external: ['vue'],


### PR DESCRIPTION
Picks up the `nestLists()` fix from `@portabletext/toolkit@6.0.0`, which is a four major jump from the `^2.0.18` this was pinned to, and brings the package in line with the org's ESM only and Node 22.12 direction.

## What was wrong

A list item can start at a level deeper than 1, and can skip any number of levels at a time. Neither was accounted for, so a level 3 item could be rendered only one list deep, and items that later returned to a shallower level could start a new list rather than continuing the one they belonged to.

Rendering `[level 3, level 1]` goes from two sibling lists to:

```html
<ul>
  <li>
    <ul>
      <li>
        <ul>
          <li>Level 3</li>
        </ul>
      </li>
    </ul>
  </li>
  <li>Level 1</li>
</ul>
```

That is the shape the reporter asked for in portabletext/toolkit#100.

## Changes

- `@portabletext/toolkit` bumped from `^2.0.18` to `^6.0.0`, and `@portabletext/types` from `^2.0.14` to `^4.0.2`
- New fixture `063-skipped-list-levels`, covering a list that starts at level 3 and a level 1 to level 4 jump and back, neither of which was covered before
- `016-deep-weird-lists` expectation updated for its "Skip a step" case, which goes from level 1 straight to level 3
- Dropped the CommonJS build. `"type": "module"` added, the `require` condition removed from `exports`, `main` now points at the ESM entry, and Vite builds only the `es` format
- Removed the `afterBuild` hook that hand copied `.d.ts` to `.d.mts` and `.d.cts`, which only existed to satisfy dual publishing
- `engines.node` declared for the first time, at `>=22.12`

## Note on the four major jump

Toolkit v3 dropped Sanity Studio v2 support, v4 raised the Node floor and removed CJS exports, v5 moved to `@portabletext/types` v4, and v6 is this list fix. **Only the list change affected anything here.** Of the 40 existing tests, exactly one failed after the bump, and it was `016-deep-weird-lists` on the "Skip a step" case.

Worth noting for the CJS decision: the toolkit losing its CJS entry point in v4 did **not** force this, because Vite bundles the toolkit into the output rather than requiring it at runtime. I verified the old dual build still worked with toolkit v6 before removing it. Dropping CJS here is an alignment choice, so it is easy to back out if you would rather keep it.

## Breaking

`require("@portabletext/vue")` no longer resolves. Use `import`, or a dynamic `await import()` from a CommonJS file.

## Verification

41 tests pass. `publint` reports "All good!", and `attw` shows green for node16 ESM, bundler and node10, with the single expected "CJS consumers need a dynamic import" warning that comes with being ESM only.

Refs portabletext/toolkit#100
